### PR TITLE
Do not parse environment variables that include hifens

### DIFF
--- a/src/ConfigServiceProvider.php
+++ b/src/ConfigServiceProvider.php
@@ -89,7 +89,7 @@ class ConfigServiceProvider implements ServiceProviderInterface
     private function doReplacementsInString(string $value): string
     {
         // replace special %env(VAR)% syntax with values from the environment
-        if (preg_match('/%env\(([a-zA-Z0-9_-]+)\)%/', $value, $matches)) {
+        if (preg_match('/%env\(([a-zA-Z0-9_]+)\)%/', $value, $matches)) {
             $value = getenv($matches[1]);
         }
 


### PR DESCRIPTION
Hifens are actually not allowed to be used in environment variable names:
```
± export FOO_FOO-BAR=baz
bash: export: `FOO_FOO-BAR=baz': not a valid identifier
```